### PR TITLE
Add missing mission_control_backend trace-all-components function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ AGENTS.md
 .tmp/
 library/alfworld/compile-flexiargs-to-deterministic-runner.flexiarg
 library/social/cluster-tooling-bootstrap.flexiarg
+.gitlibs/

--- a/scripts/windows/run-clojure-windows.bat
+++ b/scripts/windows/run-clojure-windows.bat
@@ -19,6 +19,19 @@ if errorlevel 1 (
   1>&2 echo [run-clojure-windows] ERROR: unable to create FUTON1A_DATA_DIR=%FUTON1A_DATA_DIR%
   exit /b 1
 )
+if not defined FUTON_STORAGE_ROOT set "FUTON_STORAGE_ROOT=%REPO_ROOT%\.state\storage"
+if not exist "%FUTON_STORAGE_ROOT%" mkdir "%FUTON_STORAGE_ROOT%" >nul 2>nul
+if errorlevel 1 (
+  1>&2 echo [run-clojure-windows] ERROR: unable to create FUTON_STORAGE_ROOT=%FUTON_STORAGE_ROOT%
+  exit /b 1
+)
+if not defined FUTON3C_MISSION_CONTROL_SNAPSHOT_PATH set "FUTON3C_MISSION_CONTROL_SNAPSHOT_PATH=%REPO_ROOT%\.state\mission-control\sessions.edn"
+for %%I in ("%FUTON3C_MISSION_CONTROL_SNAPSHOT_PATH%") do set "MC_SNAPSHOT_DIR=%%~dpI"
+if not exist "%MC_SNAPSHOT_DIR%" mkdir "%MC_SNAPSHOT_DIR%" >nul 2>nul
+if errorlevel 1 (
+  1>&2 echo [run-clojure-windows] ERROR: unable to create mission-control snapshot directory=%MC_SNAPSHOT_DIR%
+  exit /b 1
+)
 set "CLJ_CONFIG=%REPO_ROOT%\.clj-config"
 if not exist "%CLJ_CONFIG%" mkdir "%CLJ_CONFIG%" >nul 2>nul
 if errorlevel 1 (
@@ -32,12 +45,13 @@ if errorlevel 1 (
   1>&2 echo [run-clojure-windows] ERROR: unable to create %LOCAL_M2%
   exit /b 1
 )
-set "LOCAL_TMP=%REPO_ROOT%\.tmp\java"
-if not exist "%LOCAL_TMP%" mkdir "%LOCAL_TMP%" >nul 2>nul
+set "LOCAL_TMP_DIR=%REPO_ROOT%\.tmp\java"
+if not exist "%LOCAL_TMP_DIR%" mkdir "%LOCAL_TMP_DIR%" >nul 2>nul
 if errorlevel 1 (
-  1>&2 echo [run-clojure-windows] ERROR: unable to create %LOCAL_TMP%
+  1>&2 echo [run-clojure-windows] ERROR: unable to create %LOCAL_TMP_DIR%
   exit /b 1
 )
+set "LOCAL_TMP=%LOCAL_TMP_DIR:\=/%"
 set "TMP=%LOCAL_TMP%"
 set "TEMP=%LOCAL_TMP%"
 if defined JAVA_OPTS (

--- a/src/futon3c/peripheral/mission_control_backend.clj
+++ b/src/futon3c/peripheral/mission_control_backend.clj
@@ -932,8 +932,63 @@
                 :blocked-at blocked-at-freq}
       :detected-at (:detected-at export)})))
 
+(defn trace-all-components
+  "Trace every devmap component through the gate chain.
+   Optional dm-filter limits tracing to one devmap name (string/keyword)."
+  ([] (trace-all-components default-repo-roots nil))
+  ([arg]
+   (if (map? arg)
+     (trace-all-components arg nil)
+     (trace-all-components default-repo-roots arg)))
+  ([repos dm-filter]
+   (let [review (build-portfolio-review repos)
+         now (str (java.time.Instant/now))
+         normalized-filter (when (some? dm-filter)
+                             (str/lower-case
+                              (cond
+                                (keyword? dm-filter) (name dm-filter)
+                                :else (str dm-filter))))
+         devmaps (->> (:portfolio/devmap-summaries review)
+                      (filter (fn [dm]
+                                (if normalized-filter
+                                  (= normalized-filter
+                                     (some-> (:devmap/id dm) name str/lower-case))
+                                  true)))
+                      vec)
+         tensions (mapcat (fn [dm]
+                            (let [dm-id (:devmap/id dm)]
+                              (map (fn [component]
+                                     (let [comp-id (:component/id component)]
+                                       {:tension/type :component-trace
+                                        :tension/devmap dm-id
+                                        :tension/component comp-id
+                                        :tension/detected-at now
+                                        :tension/summary (str (name dm-id) "/" (name comp-id)
+                                                              " - component trace")}))
+                                   (:devmap/components dm))))
+                          devmaps)
+         paths (mapv #(trace-tension-path % review) tensions)
+         complete (filter :complete? paths)
+         blocked (remove :complete? paths)
+         blocked-at-freq (frequencies (keep :blocked-at blocked))
+         gap-count (count (filter :gap-at paths))
+         by-devmap (frequencies
+                    (keep (fn [p]
+                            (some-> p :tension :tension/devmap name))
+                          paths))]
+     {:paths paths
+      :summary {:total (count paths)
+                :complete (count complete)
+                :blocked (count blocked)
+                :gap-count gap-count
+                :blocked-at blocked-at-freq
+                :devmaps-scanned (count devmaps)
+                :by-devmap by-devmap
+                :filter normalized-filter}
+      :detected-at now})))
+
 ;; =============================================================================
-;; Backfill — legacy missions as evidence (D7)
+;; Backfill - legacy missions as evidence (D7)
 ;; =============================================================================
 
 (defn mission->evidence


### PR DESCRIPTION
## Summary
- add missing 	race-all-components implementation in mission_control_backend
- harden scripts/windows/run-clojure-windows.bat by creating required storage/snapshot dirs and normalizing temp path
- ignore .gitlibs/ in repo .gitignore to avoid local dependency-cache noise

## Scope
- bug-fix only; no mission-state changes